### PR TITLE
Fixes python import key functions

### DIFF
--- a/bindings/python/pyopenabe.pyx
+++ b/bindings/python/pyopenabe.pyx
@@ -119,26 +119,26 @@ cdef class PyABEContext:
         return msk
 
     def importPublicParams(self, keyBlob):
-        cdef string key = string(b"")
+        cdef string key = to_bytes(keyBlob)
         return self.thisptr.importPublicParams(key)
 
     def importPublicParams(self, authID, keyBlob):
         cdef string auth_id = to_bytes(authID)
-        cdef string key = string(b"")
-        return self.thisptr.importPublicParams(authID, key)
+        cdef string key = to_bytes(keyBlob)
+        return self.thisptr.importPublicParams(auth_id, key)
 
     def importSecretParams(self, keyBlob):
-        cdef string key = string(b"")
+        cdef string key = to_bytes(keyBlob)
         return self.thisptr.importSecretParams(key)
 
     def importSecretParams(self, authID, keyBlob):
         cdef string auth_id = to_bytes(authID)
-        cdef string key = string(b"")
-        return self.thisptr.importSecretParams(authID, key)
+        cdef string key = to_bytes(keyBlob)
+        return self.thisptr.importSecretParams(auth_id, key)
 
     def importUserKey(self, keyID, keyBlob):
         cdef string key_id = to_bytes(keyID)
-        cdef string key = string(b"")
+        cdef string key = to_bytes(keyBlob)
         return self.thisptr.importUserKey(key_id, key)
 
     def exportUserKey(self, keyID):
@@ -201,12 +201,12 @@ cdef class PyPKEContext:
 
     def importPublicKey(self, keyID, keyBlob):
         cdef string key_id = to_bytes(keyID)
-        cdef string key = string(b"")
+        cdef string key = to_bytes(keyBlob)
         return self.thisptr.importPublicKey(key_id, key)
 
     def importPrivateKey(self, keyID, keyBlob):
         cdef string key_id = to_bytes(keyID)
-        cdef string key = string(b"")
+        cdef string key = to_bytes(keyBlob)
         return self.thisptr.importPrivateKey(key_id, key)
 
     def keygen(self, keyID):
@@ -257,12 +257,12 @@ cdef class PyPKSIGContext:
 
     def importPublicKey(self, keyID, keyBlob):
         cdef string key_id = to_bytes(keyID)
-        cdef string key = string(b"")
+        cdef string key = to_bytes(keyBlob)
         return self.thisptr.importPublicKey(key_id, key)
 
     def importPrivateKey(self, keyID, keyBlob):
         cdef string key_id = to_bytes(keyID)
-        cdef string key = string(b"")
+        cdef string key = to_bytes(keyBlob)
         return self.thisptr.importPrivateKey(key_id, key)
 
     def keygen(self, keyID):

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -18,6 +18,26 @@ print("ABE CT: ", len(ct))
 pt2 = cpabe.decrypt("alice", ct)
 print("PT: ", pt2)
 assert pt1 == pt2, "Didn't recover the message!"
+
+print("Testing key import")
+
+msk = cpabe.exportSecretParams()
+mpk = cpabe.exportPublicParams()
+uk = cpabe.exportUserKey("alice")
+
+cpabe2 = openabe.CreateABEContext("CP-ABE")
+
+cpabe2.importSecretParams(msk)
+cpabe2.importPublicParams(mpk)
+cpabe2.importUserKey("alice", uk)
+
+ct = cpabe2.encrypt("((one or two) and three)", pt1)
+print("ABE CT: ", len(ct))
+
+pt2 = cpabe2.decrypt("alice", ct)
+print("PT: ", pt2)
+assert pt1 == pt2, "Didn't recover the message!"
+
 print("CP-ABE Success!")
 
 
@@ -58,7 +78,22 @@ print("KP-ABE CT size: ", len(ct))
 pt2 = kpabe.decrypt("bob", ct)
 print("PT: ", pt2)
 assert pt1 == pt2, "Didn't recover the message!"
+
+print("Testing key imports")
+msk = kpabe.exportSecretParams()
+mpk = kpabe.exportPublicParams()
+uk = kpabe.exportUserKey("bob")
+
+kpabe2 = openabe.CreateABEContext("KP-ABE")
+
+kpabe2.importSecretParams(msk)
+kpabe2.importPublicParams(mpk)
+kpabe2.importUserKey("bob", uk)
+
+ct = kpabe.encrypt("|one|date=February 1, 2018|two", pt1)
+print("KP-ABE CT size: ", len(ct))
+pt2 = kpabe.decrypt("bob", ct)
+assert pt1 == pt2, "Didn't recover the message!"
+
 print("KP-ABE Success!")
-
-
 print("All tests passed!")


### PR DESCRIPTION
Hi,
before these changes the Python binding failed importing keys since the methods didn't consider the input keyBlob and always used b"". 
With my changes this is possible. I also added some tests to check the new behavior

svituz