### PR TITLE
Add Conditional bison build for Centos 7

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -41,6 +41,12 @@ ifeq ($(ENABLE_GCOV), yes)
   SHFLAGS += $(COVERAGE_LINKER)
 endif
 
+ifeq ($(OS_FAMILY), redhat)
+    BISON_PARSER_DEF="parser_class_name=Parser"
+else
+    BISON_PARSER_DEF="api.parser.class=Parser"
+endif
+
 ZSYM_OBJS = zobject.o zerror.o zprng.o zsymcrypto.o
 
 LIBRARYH=header
@@ -55,7 +61,7 @@ zml/zelement.o:
 	$(CC) $(CCFLAGS) -c zml/zelement.c -o zelement.o
 
 zparser.o: zparser.yy
-	$(BISON) -d -v zparser.yy
+	$(BISON) -d -D $(BISON_PARSER_DEF) -v zparser.yy
 	cp *.hh $(OABE_INCLUDE_DIR)
 	$(CXX) $(CXXFLAGS) -c -o zparser.o zparser.tab.cc
 

--- a/src/zparser.yy
+++ b/src/zparser.yy
@@ -38,9 +38,6 @@
 /* namespace to enclose parser in */
 %name-prefix "oabe"
 
-/* set the parser's class identifier */
-%define api.parser.class {Parser}
-
 /* keep track of the current position within the input */
 %locations
 %initial-action


### PR DESCRIPTION
- Remove definition api.parser.class from zparser.yy
- Define either api.parser.class or parser_class_name
  depending on the value of OS_FAMILY
- Pass definition to bison as command argument