### PR TITLE
Make build work on macOS with Macports and necessary dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ clean:
 	$(MAKE) -C src clean
 	$(MAKE) -C cli clean
 	$(MAKE) -C examples clean
-	$(RM) -r $(ZROOT)/root
+	$(RM) -rf $(ZROOT)/deps/root
 
 distclean: clean
 	$(MAKE) -C deps clean

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,11 @@ bindings:
 	$(MAKE) -C bindings
 
 install-deps:
+	mkdir -p $(ZROOT)/deps/root/bin
 	mkdir -p $(INSTALL_PREFIX)
 	cp -r $(ZROOT)/deps/root/lib $(INSTALL_PREFIX)
 	cp -r $(ZROOT)/deps/root/include $(INSTALL_PREFIX)
-	cp -r $(ZROOT)/deps/root/bin $(INSTALL_PREFIX)
+	cp -rn $(ZROOT)/deps/root/bin $(INSTALL_PREFIX)
 
 install: install-deps
 	mkdir -p $(INSTALL_PREFIX)/bin

--- a/Makefile.common
+++ b/Makefile.common
@@ -9,8 +9,12 @@ endif
 DEPS_INSTALL_ZROOT = $(ZROOT)/deps/root
 OABE_LIB_ROOT = $(ZROOT)/root/lib
 INCLUDE_ROOT = $(ZROOT)/root/include
+ifndef LOCAL_LIB_ROOT
 LOCAL_LIB_ROOT = /usr/local/lib
+endif
+ifndef LOCAL_INCLUDE
 LOCAL_INCLUDE = /usr/local/include
+endif
 LOCAL_INSTALL_BIN = /usr/local/bin
 
 # Include locations
@@ -42,7 +46,8 @@ else
 endif
 
 # Set shared lib extension for each OS
-DEPS_PACKAGES = relic openssl gtest
+DEPS_PACKAGES = $(if $(USE_DEPS),$(USE_DEPS),"relic openssl gtest")
+$(info DEPS_PACKAGES: $(DEPS_PACKAGES) *** )
 ADD_CFLAGS :=
 OS_CXXFLAGS :=
 WITH_BP := 

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,7 +1,7 @@
 # Shared Makefile for 
 
-CC = g++
-CXX = g++
+CC ?= g++
+CXX ?= g++
 ifndef LDLIBS
 LDLIBS := -lgtest -lpthread
 endif

--- a/Makefile.common
+++ b/Makefile.common
@@ -47,7 +47,6 @@ endif
 
 # Set shared lib extension for each OS
 DEPS_PACKAGES = $(if $(USE_DEPS),$(USE_DEPS),"relic openssl gtest")
-$(info DEPS_PACKAGES: $(DEPS_PACKAGES) *** )
 ADD_CFLAGS :=
 OS_CXXFLAGS :=
 WITH_BP := 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -6,12 +6,15 @@ DIRS=$(DEPS_PACKAGES)
 # relic openssl gtest
 all: $(DIRS)
 	mkdir -p root/lib
+	mkdir -p root/bin
+ifndef NO_DEPS
 	for d in $(DIRS); do \
 		make -C $$d; \
 	done
+endif
 
 clean: $(DIRS)
 	rm -rf root
-	for d in $(DIRS); do \
+	for d in relic openssl gtest; do \
 		make -C $$d clean; \
 	done

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -2,8 +2,15 @@ include ../Makefile.common
 
 .PHONY: all
 
-CXXFLAGS := $(CXX11FLAGS) $(OS_CXXFLAGS) -pthread -Wall -g -O2 -DSSL_LIB_INIT -I${ZROOT}/deps/root/include -I${ZROOT}/root/include
-LDFLAGS := -L${ZROOT}/deps/root/lib -L${ZROOT}/root/lib
+ifdef LOCAL_INCLUDE
+LOC_INC="-I$(LOCAL_INCLUDE)"
+endif
+ifdef LOCAL_LIB_ROOT
+LOC_LIB="-L$(LOCAL_LIB_ROOT)"
+endif
+
+CXXFLAGS := $(CXX11FLAGS) $(OS_CXXFLAGS) -pthread -Wall -g -O2 -DSSL_LIB_INIT -I${ZROOT}/deps/root/include -I${ZROOT}/root/include $(LOC_INC)
+LDFLAGS := -L${ZROOT}/deps/root/lib -L${ZROOT}/root/lib $(LOC_LIB)
 LIBS := -lcrypto -lrelic -lrelic_ec -lopenabe
 
 all: test_kp test_cp test_pk test_km

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.common
 
 .PHONY: all
 
-CXXFLAGS := $(CXX11FLAGS)$(OS_CXXFLAGS) -pthread -Wall -g -O2 -DSSL_LIB_INIT -I${ZROOT}/deps/root/include -I${ZROOT}/root/include
+CXXFLAGS := $(CXX11FLAGS) $(OS_CXXFLAGS) -pthread -Wall -g -O2 -DSSL_LIB_INIT -I${ZROOT}/deps/root/include -I${ZROOT}/root/include
 LDFLAGS := -L${ZROOT}/deps/root/lib -L${ZROOT}/root/lib
 LIBS := -lcrypto -lrelic -lrelic_ec -lopenabe
 

--- a/macport.env
+++ b/macport.env
@@ -1,0 +1,22 @@
+#
+# To configure openabe to build using dependencies installed by
+# Macports - usually, OpenSSL and gtest - source this file
+# via bash before doing "make" in the openabe top directory,
+# like
+#     $ source macport.emv
+#     $ make && make test
+#
+source ./env
+export ADD_CFLAGS="-I/opt/local/include -march=native"
+export BISON="bison"
+export USE_DEPS="relic"
+export LDFLAGS="-L/opt/local/lib -lgtest"
+export LOCAL_LIB_ROOT="/opt/local/lib"
+export LOCAL_INCLUDE="/opt/local/include"
+#export NO_DEPS="none"
+unset NO_DEPS
+export OS_CXXFLAGS="-I/opt/local/include -march=native"
+#export ZML_LIB="with_openssl"
+unset ZML_LIB
+export ZSYM_DEP_LIBS="-L/opt/local/lib -lcrypto"
+export ZROOT="${PWD}"

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,7 @@ CC ?= gcc
 OABE_INCLUDE_DIR := $(INCLUDE_ROOT)/openabe
 CXX11FLAGS += $(CXXFLAGS)
 
+$(info CXX11FLAGS: $(CXX11FLAGS) )
 RELICLIBS = -lrelic_s 
 #$(DEPS_INSTALL_ROOT)/lib/librelic_s.a
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.common
 
 .PHONY: all clean header
 
-CC = gcc
+CC ?= gcc
 
 OABE_INCLUDE_DIR := $(INCLUDE_ROOT)/openabe
 CXX11FLAGS += $(CXXFLAGS)

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -5,6 +5,8 @@ OABELIB = libopenabe.a
 
 AR = ar
 MAKE = make
+ifndef BISON
 BISON = ${ZROOT}/bin/bison
+endif
 FLEX = flex
 INSTALL = install

--- a/src/include/openabe/zml/zelement_bp.h
+++ b/src/include/openabe/zml/zelement_bp.h
@@ -273,4 +273,4 @@ typedef OpenABEElementList::iterator OpenABEElementListIterator;
 void multi_bp_map_op(const bp_group_t group, oabe::GT& gt,
                      std::vector<oabe::G1>& g1, std::vector<oabe::G2>& g2);
 
-#endif	// __ZELEMENT_H__
+#endif	// __ZELEMENT_BP_H__


### PR DESCRIPTION
1. Fixes #41 and #42. 
2. Fixes some other bugs and typos - didn't think it worth opening separate issues for them.
3. Allows use of dependencies that are already installed system-wide, which helps avoiding conflict between different versions of shared libraries of the same packages - e.g., OpenSSL.
