### PR TITLE
Fixing clean, distclean, and omission of LOCAL_INCLUDE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,5 @@ clean:
 	$(MAKE) -C examples clean
 	$(RM) -rf $(ZROOT)/deps/root
 
-distclean: clean
-	$(MAKE) -C deps clean
+distclean:	clean
+	$(MAKE) -C deps distclean

--- a/Makefile.common
+++ b/Makefile.common
@@ -19,13 +19,13 @@ LOCAL_INSTALL_BIN = /usr/local/bin
 
 # Include locations
 #  Dependencies (C/C++)
-CCFLAGS := -I$(DEPS_INSTALL_ZROOT)/include
+CCFLAGS = -I$(DEPS_INSTALL_ZROOT)/include
 CXXFLAGS := -I$(DEPS_INSTALL_ZROOT)/include
 #  Local includes (for generated headers from bison/flex)
 CXXFLAGS += -I$(ZROOT)/src
 #  Common includes (C/C++)
-CCFLAGS += -I$(INCLUDE_ROOT)
-CXXFLAGS += -I$(INCLUDE_ROOT)
+CCFLAGS += -I$(INCLUDE_ROOT) -I$(LOCAL_INCLUDE)
+CXXFLAGS += -I$(INCLUDE_ROOT) -I$(LOCAL_INCLUDE)
 
 RELIC_LIB = -lrelic -lrelic_ec
 GMP_LIB = -lgmp
@@ -61,7 +61,6 @@ ifeq ($(OS), Windows_NT)
     CMAKE_VARS := -DCMAKE_MAKE_PROGRAM=/mingw64/bin/mingw32-make -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++.exe CMAKE_INCLUDE_PATH="/usr/local/include" CMAKE_LIBRARY_PATH="/usr/local/lib"
     SHLIB := dll
     GTESTEXT := $(SHLIB)
-    CCFLAGS += -I$(LOCAL_INCLUDE)
     # No need to set -fPIC for windows as all code is position independent by default.
     CXXFLAGS += -DGTEST_USE_OWN_TR1_TUPLE=0 -I/usr/local/include/ -I/usr/include
     SHFLAGS := -nostartfiles
@@ -97,7 +96,8 @@ else
        SHLIB = dylib
        GTESTEXT = 0.$(SHLIB)
        # pull in headers installed via brew (for gmp/relic/openssl)
-       CXXFLAGS += -I$(LOCAL_INCLUDE)
+       CCFLAGS += -fPIC
+       CXXFLAGS += -I$(LOCAL_INCLUDE) $(OS_CXXFLAGS)
        # include the clang C++ standard library (as a result, enable TR1_TUPLE flag)
        CXXFLAGS += -stdlib=libc++ -DGTEST_USE_OWN_TR1_TUPLE=1 -Wno-deprecated
        # (Option to use GMP with OpenSSL?): -DOPENSSL_USE_GMP -lgmp

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -9,7 +9,7 @@ OABE_LIB = $(OABE_LIB_ROOT)/$(OABELIB)
 all: $(BINOBJS)
 
 clean:
-	-rm -rf *.o $(TESTOBJS) $(BINOBJS) $(OABELIB)
+	-rm -rf *.o *.dSYM input.txt $(TESTOBJS) $(BINOBJS) $(OABELIB)
 
 install: $(BINOBJS)
 	for b in $(BINOBJS); do \

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -18,3 +18,9 @@ clean: $(DIRS)
 	for d in relic openssl gtest; do \
 		make -C $$d clean; \
 	done
+
+distclean: $(DIRS)
+	rm -rf root
+	for d in relic openssl gtest; do \
+		make -C $$d distclean; \
+	done

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -19,7 +19,7 @@ clean: $(DIRS)
 		make -C $$d clean; \
 	done
 
-distclean: $(DIRS)
+distclean: clean
 	rm -rf root
 	for d in relic openssl gtest; do \
 		make -C $$d distclean; \

--- a/deps/gtest/Makefile
+++ b/deps/gtest/Makefile
@@ -24,3 +24,6 @@ googletest-release-$(VERSION): googletest-release-$(VERSION).zip
 
 clean:
 	rm -rf googletest-release-$(VERSION)
+
+distclean:
+	rm -rf googletest-release-$(VERSION)*

--- a/src/Makefile
+++ b/src/Makefile
@@ -132,7 +132,7 @@ test_zsym: $(ZSYMLIB)
 	$(CXX) -o test_zsym $(CXX11FLAGS) $(LDFLAGS) -L. test_zsym.cpp $(ZSYMLIB) $(ZSYM_DEP_LIBS)
 
 clean:
-	-rm -rf *.o a.out $(PROGRAMS) $(OABELIB) $(OABE_SHLIB) $(ZSYMLIB) $(GENFILES)
+	-rm -rf *.o *.dSYM a.out zparser.output $(PROGRAMS) $(OABELIB) $(OABE_SHLIB) $(ZSYMLIB) $(GENFILES)
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $<


### PR DESCRIPTION
`make clean` does not clean debug artifacts `*.dSYM` and test artifacts `zparser.outut` and such properly and consistsenly.

`make distclean` does not remove pulled dependencies.

`LOCAL_INCLUDE` is not added to the `CCFLAGS` in `Makefile.common`, which makes compilation of `src/zml/zelement.c` to fail if dependencies have their headers in `LOCAL_INCLUDE`.

This PR fixes #45 and #46 