### PR TITLE
Fix linking, running tests, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ clean:
 	$(MAKE) -C cli clean
 	$(MAKE) -C examples clean
 	$(RM) -rf $(ZROOT)/deps/root
+	$(RM) -rf $(ZROOT)/root/lib/* $(ZROOT)/root/include/*
 
 distclean:	clean
 	$(MAKE) -C deps distclean

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifndef ZROOT
     $(error ZROOT is undefined. Need to source env file: . ./env)
 endif
 
-INSTALL_PREFIX := /usr/local
+INSTALL_PREFIX = /usr/local
 
 docs:
 	$(MAKE) -C docs

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,4 +1,4 @@
-# Shared Makefile for 
+# Shared Makefile for openabe build from the source
 
 CC ?= g++
 CXX ?= g++
@@ -9,13 +9,9 @@ endif
 DEPS_INSTALL_ZROOT = $(ZROOT)/deps/root
 OABE_LIB_ROOT = $(ZROOT)/root/lib
 INCLUDE_ROOT = $(ZROOT)/root/include
-ifndef LOCAL_LIB_ROOT
-LOCAL_LIB_ROOT = /usr/local/lib
-endif
-ifndef LOCAL_INCLUDE
-LOCAL_INCLUDE = /usr/local/include
-endif
-LOCAL_INSTALL_BIN = /usr/local/bin
+LOCAL_LIB_ROOT ?= /usr/local/lib
+LOCAL_INCLUDE ?= /usr/local/include
+LOCAL_INSTALL_BIN ?= /usr/local/bin
 
 # Include locations
 #  Dependencies (C/C++)
@@ -28,6 +24,7 @@ CCFLAGS += -I$(INCLUDE_ROOT) -I$(LOCAL_INCLUDE)
 CXXFLAGS += -I$(INCLUDE_ROOT) -I$(LOCAL_INCLUDE)
 
 RELIC_LIB = -lrelic -lrelic_ec
+RELIC_LIB_STATIC = -lrelic_s -lrelic_s_ec
 GMP_LIB = -lgmp
 SSL_LIB = -lssl
 CRYPTO_LIB = -lcrypto
@@ -141,12 +138,12 @@ else
   # relic-only build for math ops
   CXXFLAGS += $(OPENSSL_ZML)
   CCFLAGS += -g -O2 $(OPENSSL_ZML) $(ADD_CFLAGS) 
-  OABELDLIBS = $(RELIC_LIB)
+  OABELDLIBS = $(RELIC_LIB_STATIC)
   OABELDSHLIBS = $(RELIC_LIB)
 endif
 # remaining deps
-OABELDLIBS += $(SSL_LIB) $(CRYPTO_LIB)
-OABELDSHLIBS += $(SSL_LIB) $(CRYPTO_LIB)
+OABELDLIBS += $(SSL_LIB) $(CRYPTO_LIB) $(GMP_LIB)
+OABELDSHLIBS += $(SSL_LIB) $(CRYPTO_LIB) $(GMP_LIB)
 
 SHLIB_PATH = $(LDFLAGS)
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -2,9 +2,8 @@
 
 CC ?= g++
 CXX ?= g++
-ifndef LDLIBS
-LDLIBS := -lgtest -lpthread
-endif
+
+LDLIBS ?= -lgtest -lpthread
 
 DEPS_INSTALL_ZROOT = $(ZROOT)/deps/root
 OABE_LIB_ROOT = $(ZROOT)/root/lib

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -19,16 +19,16 @@ install: $(BINOBJS)
 # NOTE: order of library matters: libztk first, then relic, then gmp
 # if relic goes before ztk, then you'll see a bunch of undefined references to relic symbols!
 oabe_setup: $(OBJS)
-	$(CXX) -o oabe_setup $(OBJS) -I../src/ $(CXXFLAGS) $(LDFLAGS) $(CUR_DIR)/setup.cpp $(OABE_LIB) $(OABELDLIBS)
+	$(CXX) -o oabe_setup $(OBJS) -I../src/ $(CXXFLAGS) $(LDFLAGS) $(CUR_DIR)/setup.cpp $(OABE_LIB) $(OABELDSHLIBS)
 
 oabe_keygen: $(OBJS)
-	$(CXX) -o oabe_keygen $(OBJS) -I../src/ $(CXXFLAGS) $(LDFLAGS) $(CUR_DIR)/keygen.cpp $(OABE_LIB) $(OABELDLIBS)
+	$(CXX) -o oabe_keygen $(OBJS) -I../src/ $(CXXFLAGS) $(LDFLAGS) $(CUR_DIR)/keygen.cpp $(OABE_LIB) $(OABELDSHLIBS)
 
 oabe_enc: $(OBJS)
-	$(CXX) -o oabe_enc $(OBJS) -I../src/ $(CXXFLAGS) $(LDFLAGS) $(CUR_DIR)/encrypt.cpp $(OABE_LIB) $(OABELDLIBS)
+	$(CXX) -o oabe_enc $(OBJS) -I../src/ $(CXXFLAGS) $(LDFLAGS) $(CUR_DIR)/encrypt.cpp $(OABE_LIB) $(OABELDSHLIBS)
 
 oabe_dec: $(OBJS)
-	$(CXX) -o oabe_dec $(OBJS) -I../src/ $(CXXFLAGS) $(LDFLAGS) $(CUR_DIR)/decrypt.cpp $(OABE_LIB) $(OABELDLIBS)
+	$(CXX) -o oabe_dec $(OBJS) -I../src/ $(CXXFLAGS) $(LDFLAGS) $(CUR_DIR)/decrypt.cpp $(OABE_LIB) $(OABELDSHLIBS)
 
 %.o: %.c
 	$(CC) $(CCFLAGS) -c $<

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -9,9 +9,9 @@ ifdef LOCAL_LIB_ROOT
 LOC_LIB="-L$(LOCAL_LIB_ROOT)"
 endif
 
-CXXFLAGS := $(CXX11FLAGS) $(OS_CXXFLAGS) -pthread -Wall -g -O2 -DSSL_LIB_INIT -I${ZROOT}/deps/root/include -I${ZROOT}/root/include $(LOC_INC)
-LDFLAGS := -L${ZROOT}/deps/root/lib -L${ZROOT}/root/lib $(LOC_LIB)
-LIBS := -lcrypto -lrelic -lrelic_ec -lopenabe
+CXXFLAGS = $(CXX11FLAGS) $(OS_CXXFLAGS) -pthread -Wall -g -O2 -DSSL_LIB_INIT -I${ZROOT}/deps/root/include -I${ZROOT}/root/include $(LOC_INC)
+LDFLAGS = -L${ZROOT}/deps/root/lib -L${ZROOT}/root/lib $(LOC_LIB)
+LIBS = -lcrypto -lrelic -lrelic_ec -lopenabe
 
 all: test_kp test_cp test_pk test_km
 

--- a/macport.env
+++ b/macport.env
@@ -40,4 +40,4 @@ export ZROOT="${PWD}"
 #
 # Where to install "openabe" (following sets it to where Macports
 # installs binaries):
-export LOCAL_INSTALL_BIN="/opt/local/bin"
+export INSTALL_PREFIX="/opt/local"

--- a/macport.env
+++ b/macport.env
@@ -6,17 +6,38 @@
 #     $ source macport.emv
 #     $ make && make test
 #
+# To install, do (after making sure "LOCAL_INSTALL_BIN" points where ypu want it to):
+#
+#     $ sudo -EH make install
+#
 source ./env
-export ADD_CFLAGS="-I/opt/local/include -march=native"
+# For the case when "bison" in on the PATH
 export BISON="bison"
+# What dependencies to pull and build within this process. Options are
+# "relic, openssl, gtest" or any subset thereof.
 export USE_DEPS="relic"
+#
+# Where to find dependencies and extra header files/libraries
+# The following points at those installed by Macports
+export ADD_CFLAGS="-I/opt/local/include -march=native"
 export LDFLAGS="-L/opt/local/lib -lgtest"
 export LOCAL_LIB_ROOT="/opt/local/lib"
 export LOCAL_INCLUDE="/opt/local/include"
+export OS_CXXFLAGS="-I/opt/local/include -march=native"
+#
+# Point at the installed OpenSSL library
+export ZSYM_DEP_LIBS="-L/opt/local/lib -lcrypto"
+#
+# Uncomment the following *only* if you already have RELIC, OpenSSL, and GTest 
+# installed where this build can find them
 #export NO_DEPS="none"
 unset NO_DEPS
-export OS_CXXFLAGS="-I/opt/local/include -march=native"
+# Note: uncomment the following *only* if you will use Zeutro fork of
+# the OpenSSL package!
 #export ZML_LIB="with_openssl"
 unset ZML_LIB
-export ZSYM_DEP_LIBS="-L/opt/local/lib -lcrypto"
 export ZROOT="${PWD}"
+#
+# Where to install "openabe" (following sets it to where Macports
+# installs binaries):
+export LOCAL_INSTALL_BIN="/opt/local/bin"

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,6 @@ CC ?= gcc
 OABE_INCLUDE_DIR := $(INCLUDE_ROOT)/openabe
 CXX11FLAGS += $(CXXFLAGS)
 
-$(info CXX11FLAGS: $(CXX11FLAGS) )
 RELICLIBS = -lrelic_s 
 #$(DEPS_INSTALL_ROOT)/lib/librelic_s.a
 
@@ -133,6 +132,7 @@ test_zsym: $(ZSYMLIB)
 
 clean:
 	-rm -rf *.o *.dSYM a.out zparser.output $(PROGRAMS) $(OABELIB) $(OABE_SHLIB) $(ZSYMLIB) $(GENFILES)
+	-rm -f librelic*.$(SHLIB) libcrypto.$(SHLIB) libsl.$(SHLIB) libgtest*.$(SHLIB)
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $<


### PR DESCRIPTION
This PR fixes #48 .

Allows running tests before the shared libraries (particularly important for dependencies) are installed - matters if one wants to ensure things work before installing binaries system-wide. Fix is linking tests (`test_libopenabe` and such) to the static version of those libraries, instead of dynamic...

Ensures the CLI is linked against dynamic libraries.

Ensures `make clean` cleans *all* the relevant build artifacts.

Adds a bunch of comments to `macport.env` to make clearer when to set what env var, and for what purpose.

Minor refactoring to simplify `Makefile.common`.