### PR TITLE
fixed dependency Makefile

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -46,7 +46,7 @@ else
 endif
 
 # Set shared lib extension for each OS
-DEPS_PACKAGES = $(if $(USE_DEPS),$(USE_DEPS),"relic openssl gtest")
+DEPS_PACKAGES = $(if $(USE_DEPS),$(USE_DEPS),relic openssl gtest)
 ADD_CFLAGS :=
 OS_CXXFLAGS :=
 WITH_BP := 


### PR DESCRIPTION
In commit 493a0d230b2e390f386f6f62673a4f2e6319ca0e, two more quotes were added. This resulted in failing to run the Makefile. This patch removed the unnecessary quotes.