### PR TITLE
Make Makefile respect INSTALL_PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifndef ZROOT
     $(error ZROOT is undefined. Need to source env file: . ./env)
 endif
 
-INSTALL_PREFIX = /usr/local
+INSTALL_PREFIX ?= /usr/local
 
 docs:
 	$(MAKE) -C docs

--- a/macport.env
+++ b/macport.env
@@ -6,7 +6,8 @@
 #     $ source macport.emv
 #     $ make && make test
 #
-# To install, do (after making sure "LOCAL_INSTALL_BIN" points where ypu want it to):
+# To install, do (after making sure "INSTALL_PREFIX" (and "LOCAL_INSTALL_BIN") point
+# where you want the process to install the binaries):
 #
 #     $ sudo -EH make install
 #
@@ -41,3 +42,6 @@ export ZROOT="${PWD}"
 # Where to install "openabe" (following sets it to where Macports
 # installs binaries):
 export INSTALL_PREFIX="/opt/local"
+# Even though LOCAL_INSTALL_BIN seems deprecated now, make sure
+# it points at the correct place
+export LOCAL_INSTALL_BIN="${INSTALL_PREFIX}/bin"


### PR DESCRIPTION
Fixes #52, ensures env var `INSTALL_PREFIX` is respected by Makefile, and not overridden by what's in the Makefile itself.

Also clarifies and expands the comments in `macport.env` regarding use of install-related env vars.