### PR TITLE
Can be installed in a RPI-0

### DIFF
--- a/deps/gtest/download_gtest.sh
+++ b/deps/gtest/download_gtest.sh
@@ -7,7 +7,7 @@ if [[ $VERSION = "" ]]; then
 fi
 
 GTEST_VERSION=googletest-release-${VERSION}.zip
-GTEST_LINK=https://github.com/google/googletest/releases/tag/release-${VERSION}.zip
+GTEST_LINK=https://github.com/google/googletest/archive/refs/tags/release-${VERSION}.zip
 
 if [[ ! -f ${GTEST_VERSION} ]]; then
     wget -O ${GTEST_VERSION} ${GTEST_LINK}

--- a/deps/gtest/download_gtest.sh
+++ b/deps/gtest/download_gtest.sh
@@ -7,7 +7,7 @@ if [[ $VERSION = "" ]]; then
 fi
 
 GTEST_VERSION=googletest-release-${VERSION}.zip
-GTEST_LINK=https://github.com/google/googletest/archive/release-${VERSION}.zip
+GTEST_LINK=https://github.com/google/googletest/releases/tag/release-${VERSION}.zip
 
 if [[ ! -f ${GTEST_VERSION} ]]; then
     wget -O ${GTEST_VERSION} ${GTEST_LINK}

--- a/deps/relic/Makefile
+++ b/deps/relic/Makefile
@@ -1,3 +1,10 @@
+# this file is based on the following file of the OpenABE library:
+# https://github.com/zeutro/openabe/blob/master/deps/relic/Makefile
+# with minor modifications made by IBM to allow compilation with ARM architecture
+# extracted from: https://github.com/IBM/openabe/blob/master/src/Makefile
+# and minor modifications following the issue solved in: https://github.com/relic-toolkit/relic/issues/211
+
+
 .PHONY: all clean
 
 include ../../Makefile.common
@@ -27,14 +34,14 @@ all: package relic-$(VERSION)/.built
 #-DLABEL="$(BP_LABEL)"
 relic-$(VERSION)/.built: relic-${VERSION}
 	cd $(BP_TMP); \
-	$(CMAKE_VARS) COMP="-O2 -funroll-loops -fomit-frame-pointer -Wno-incompatible-pointer-types -Wno-unused-function -Wno-implicit-function-declaration -Wno-incompatible-pointer-types-discards-qualifiers" cmake $(COMPILER_VARS) -DCMAKE_INSTALL_PREFIX:PATH=$(DEPS_INSTALL_ZROOT) -DOPSYS=$(RELIC_OS) -DARCH="X64" \
-	-DWITH="BN;DV;FP;FPX;EP;EPX;PP;PC;MD" -DCHECK=off -DVERBS=off -DDEBUG=off -DMULTI=PTHREAD -DBENCH=0 -DTESTS=10 -DARITH=x64-asm-$(BN_CURVE) -DFP_PRIME=$(BN_CURVE) -DBN_PRECI=$(BN_CURVE) \
+	$(CMAKE_VARS) COMP="-O2 -funroll-loops -fomit-frame-pointer -Wno-incompatible-pointer-types -Wno-unused-function -Wno-implicit-function-declaration -Wno-incompatible-pointer-types-discards-qualifiers" cmake $(COMPILER_VARS) -DCMAKE_INSTALL_PREFIX:PATH=$(DEPS_INSTALL_ZROOT) -DOPSYS=$(RELIC_OS) -DARCH="ARM" -DWSIZE=32 \
+	-DWITH="BN;DV;FP;FPX;EP;EPX;PP;PC;MD" -DCHECK=off -DVERBS=off -DDEBUG=off -DMULTI=PTHREAD -DBENCH=0 -DTESTS=10 -DARITH=easy -DFP_PRIME=$(BN_CURVE) -DBN_PRECI=$(BN_CURVE) \
 	-DFP_QNRES=on -DEP_METHD="PROJC;LWNAF;COMBS;INTER" -DFP_METHD="BASIC;COMBA;COMBA;MONTY;LOWER;SLIDE" -DFPX_METHD="INTEG;INTEG;LAZYR" -DPP_METHD="LAZYR;OATEP" \
 	-DSEED="ZERO" -DRAND="CALL" ../$<; \
 	make && \
 	make install && \
 	cd ../$(EC_TMP); \
-	$(CMAKE_VARS) COMP="-O2 -funroll-loops -fomit-frame-pointer -Wno-unused-function -Wno-implicit-function-declaration -Wno-incompatible-pointer-types-discards-qualifiers" cmake $(COMPILER_VARS) -DCMAKE_INSTALL_PREFIX:PATH=$(DEPS_INSTALL_ZROOT) -DOPSYS=$(RELIC_OS) -DARCH="X64" \
+	$(CMAKE_VARS) COMP="-O2 -funroll-loops -fomit-frame-pointer -Wno-unused-function -Wno-implicit-function-declaration -Wno-incompatible-pointer-types-discards-qualifiers" cmake $(COMPILER_VARS) -DCMAKE_INSTALL_PREFIX:PATH=$(DEPS_INSTALL_ZROOT) -DOPSYS=$(RELIC_OS) -DARCH="ARM" -DWSIZE=32 \
 	-DWITH="BN;DV;FP;EP;MD" -DCHECK=off -DVERBS=off -DDEBUG=off -DMULTI=PTHREAD -DBENCH=0 -DTESTS=0 -DARITH=gmp -DFP_PRIME=$(EC_CURVE) \
 	-DFP_QNRES=off -DEP_METHD="PROJC;LWNAF;COMBS;INTER" -DFP_METHD="BASIC;COMBA;COMBA;MONTY;LOWER;SLIDE" -DFPX_METHD="INTEG;INTEG;LAZYR" -DPP_METHD="LAZYR;OATEP" \
 	-DSEED="ZERO" -DRAND="CALL" -DLABEL="$(EC_LABEL)" ../$<; \


### PR DESCRIPTION
I updated some files to make the library work in a RPI-0 (ARMv6) (as I introduced in #62).

Changing `-DARITH=arm-asm-254` to -`DARITH=easy` in the Makefile let me compile both in armv6 (RPI0-W) and armv8 (RPI4). The solution is based in the answers provided [here](https://github.com/relic-toolkit/relic/issues/211) and the file modifications [made by IBM](https://github.com/IBM/openabe).

It has been tested in a RPI0 with Raspbian Stretch and in a RPI4 with 32-bit Ubuntu Server TLS.

Note: the library has not been tested performance-wise with the changes made to the Makefile, but I hope it is useful for other folks working with ARMv6 and older architectures.